### PR TITLE
Fix package dependencies so rosdep successfully resolves them

### DIFF
--- a/tesseract_ros/tesseract_monitoring/package.xml
+++ b/tesseract_ros/tesseract_monitoring/package.xml
@@ -17,7 +17,6 @@
   <depend>tesseract_rosutils</depend>
   <depend>tesseract_msgs</depend>
   <depend>pluginlib</depend>
-  <depend>dynamic_reconfigure</depend>
   <depend>tf2_ros</depend>
   <depend>tf2_eigen</depend>
 

--- a/tesseract_ros/tesseract_msgs/package.xml
+++ b/tesseract_ros/tesseract_msgs/package.xml
@@ -11,7 +11,6 @@
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
   <build_depend>rosidl_default_generators</build_depend>
   
-  <exec_depend>message_runtime</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
   <member_of_group>rosidl_interface_packages</member_of_group>
 

--- a/tesseract_ros/tesseract_rosutils/package.xml
+++ b/tesseract_ros/tesseract_rosutils/package.xml
@@ -19,6 +19,8 @@
   <depend>tesseract_common</depend>
   <depend>tesseract_process_planners</depend>
 
+  <depend>octomap</depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Remove depend tags for non-ROS2 packages, add correct tag for octomap.