### PR TITLE
Add try/catch block around tf broadcaster call

### DIFF
--- a/tesseract_ros/tesseract_monitoring/src/current_state_monitor.cpp
+++ b/tesseract_ros/tesseract_monitoring/src/current_state_monitor.cpp
@@ -378,7 +378,14 @@ void CurrentStateMonitor::jointStateCallback(const sensor_msgs::msg::JointState:
         transforms.push_back(tf);
       }
     }
-    tf_broadcaster_.sendTransform(transforms);
+    try
+    {
+      tf_broadcaster_.sendTransform(transforms);
+    }
+    catch(std::exception &e)
+    {
+      RCLCPP_ERROR(node_->get_logger(), "%s", e);
+    }
   }
 
   // callbacks, if needed


### PR DESCRIPTION
The TF broadcaster can raise errors, so this adds a try/catch block to prevent them from going uncaught and crashing the node.